### PR TITLE
ext_proc: attributes in first message to server

### DIFF
--- a/api/envoy/service/ext_proc/v3/BUILD
+++ b/api/envoy/service/ext_proc/v3/BUILD
@@ -7,6 +7,7 @@ licenses(["notice"])  # Apache 2
 api_proto_package(
     has_services = True,
     deps = [
+        "//envoy/annotations:pkg",
         "//envoy/config/core/v3:pkg",
         "//envoy/extensions/filters/http/ext_proc/v3:pkg",
         "//envoy/type/v3:pkg",

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -199,8 +199,6 @@ message ProcessingResponse {
 // This message is sent to the external server when the HTTP request and responses
 // are first received.
 message HttpHeaders {
-  reserved 2;
-
   // The HTTP request headers. All header keys will be
   // lower-cased, because HTTP header keys are case-insensitive.
   // The ``headers`` encoding is based on the runtime guard
@@ -210,6 +208,12 @@ message HttpHeaders {
   // When it is false, the header value is encoded in the
   // :ref:`value <envoy_v3_api_field_config.core.v3.HeaderValue.value>` field.
   config.core.v3.HeaderMap headers = 1;
+
+  // [#not-implemented-hide:]
+  // This field is deprecated and not implemented. Attributes will be sent in
+  // the  top-level :ref:`attributes <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.attributes`
+  // field.
+  map<string, google.protobuf.Struct> attributes = 2;
 
   // If true, then there is no message body associated with this
   // request or response.

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -113,7 +113,6 @@ message ProcessingRequest {
   // Dynamic metadata associated with the request.
   config.core.v3.Metadata metadata_context = 8;
 
-  // [#not-implemented-hide:]
   // The values of properties selected by the ``request_attributes``
   // or ``response_attributes`` list in the configuration. Each entry
   // in the list is populated from the standard
@@ -200,6 +199,8 @@ message ProcessingResponse {
 // This message is sent to the external server when the HTTP request and responses
 // are first received.
 message HttpHeaders {
+  reserved 2;
+
   // The HTTP request headers. All header keys will be
   // lower-cased, because HTTP header keys are case-insensitive.
   // The ``headers`` encoding is based on the runtime guard
@@ -209,15 +210,6 @@ message HttpHeaders {
   // When it is false, the header value is encoded in the
   // :ref:`value <envoy_v3_api_field_config.core.v3.HeaderValue.value>` field.
   config.core.v3.HeaderMap headers = 1;
-
-  // [#not-implemented-hide:]
-  // TODO(jbohanon) reserve field as part of rework detailed in https://github.com/envoyproxy/envoy/issues/32125
-  // The values of properties selected by the ``request_attributes``
-  // or ``response_attributes`` list in the configuration. Each entry
-  // in the list is populated
-  // from the standard :ref:`attributes <arch_overview_attributes>`
-  // supported across Envoy.
-  map<string, google.protobuf.Struct> attributes = 2;
 
   // If true, then there is no message body associated with this
   // request or response.

--- a/api/envoy/service/ext_proc/v3/external_processor.proto
+++ b/api/envoy/service/ext_proc/v3/external_processor.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package envoy.service.ext_proc.v3;
 
+import "envoy/annotations/deprecation.proto";
 import "envoy/config/core/v3/base.proto";
 import "envoy/extensions/filters/http/ext_proc/v3/processing_mode.proto";
 import "envoy/type/v3/http_status.proto";
@@ -213,7 +214,8 @@ message HttpHeaders {
   // This field is deprecated and not implemented. Attributes will be sent in
   // the  top-level :ref:`attributes <envoy_v3_api_field_service.ext_proc.v3.ProcessingRequest.attributes`
   // field.
-  map<string, google.protobuf.Struct> attributes = 2;
+  map<string, google.protobuf.Struct> attributes = 2
+      [deprecated = true, (envoy.annotations.deprecated_at_minor_version) = "3.0"];
 
   // If true, then there is no message body associated with this
   // request or response.

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -276,8 +276,7 @@ void Filter::onDestroy() {
 }
 
 FilterHeadersStatus Filter::onHeaders(ProcessorState& state,
-                                      Http::RequestOrResponseHeaderMap& headers, bool end_stream,
-                                      ProtobufWkt::Struct* proto) {
+                                      Http::RequestOrResponseHeaderMap& headers, bool end_stream) {
   switch (openStream()) {
   case StreamOpenState::Error:
     return FilterHeadersStatus::StopIteration;
@@ -291,14 +290,12 @@ FilterHeadersStatus Filter::onHeaders(ProcessorState& state,
   state.setHeaders(&headers);
   state.setHasNoBody(end_stream);
   ProcessingRequest req;
+  addAttributes(state, req);
   addDynamicMetadata(state, req);
   auto* headers_req = state.mutableHeaders(req);
   MutationUtils::headersToProto(headers, config_->allowedHeaders(), config_->disallowedHeaders(),
                                 *headers_req->mutable_headers());
   headers_req->set_end_of_stream(end_stream);
-  if (proto != nullptr) {
-    (*headers_req->mutable_attributes())[FilterName] = *proto;
-  }
   state.onStartProcessorCall(std::bind(&Filter::onMessageTimeout, this), config_->messageTimeout(),
                              ProcessorState::CallbackState::HeadersCallback);
   ENVOY_LOG(debug, "Sending headers message");
@@ -317,17 +314,7 @@ FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool end_st
 
   FilterHeadersStatus status = FilterHeadersStatus::Continue;
   if (decoding_state_.sendHeaders()) {
-    ProtobufWkt::Struct proto;
-
-    if (config_->expressionManager().hasRequestExpr()) {
-      auto activation_ptr = Filters::Common::Expr::createActivation(
-          &config_->expressionManager().localInfo(), decoding_state_.callbacks()->streamInfo(),
-          &headers, nullptr, nullptr);
-      proto = config_->expressionManager().evaluateRequestAttributes(*activation_ptr);
-    }
-
-    status = onHeaders(decoding_state_, headers, end_stream,
-                       config_->expressionManager().hasRequestExpr() ? &proto : nullptr);
+    status = onHeaders(decoding_state_, headers, end_stream);
     ENVOY_LOG(trace, "onHeaders returning {}", static_cast<int>(status));
   } else {
     ENVOY_LOG(trace, "decodeHeaders: Skipped header processing");
@@ -590,7 +577,7 @@ FilterTrailersStatus Filter::onTrailers(ProcessorState& state, Http::HeaderMap& 
 FilterTrailersStatus Filter::decodeTrailers(RequestTrailerMap& trailers) {
   ENVOY_LOG(trace, "decodeTrailers");
   const auto status = onTrailers(decoding_state_, trailers);
-  ENVOY_LOG(trace, "encodeTrailers returning {}", static_cast<int>(status));
+  ENVOY_LOG(trace, "decodeTrailers returning {}", static_cast<int>(status));
   return status;
 }
 
@@ -605,17 +592,7 @@ FilterHeadersStatus Filter::encodeHeaders(ResponseHeaderMap& headers, bool end_s
 
   FilterHeadersStatus status = FilterHeadersStatus::Continue;
   if (!processing_complete_ && encoding_state_.sendHeaders()) {
-    ProtobufWkt::Struct proto;
-
-    if (config_->expressionManager().hasResponseExpr()) {
-      auto activation_ptr = Filters::Common::Expr::createActivation(
-          &config_->expressionManager().localInfo(), encoding_state_.callbacks()->streamInfo(),
-          nullptr, &headers, nullptr);
-      proto = config_->expressionManager().evaluateResponseAttributes(*activation_ptr);
-    }
-
-    status = onHeaders(encoding_state_, headers, end_stream,
-                       config_->expressionManager().hasResponseExpr() ? &proto : nullptr);
+    status = onHeaders(encoding_state_, headers, end_stream);
     ENVOY_LOG(trace, "onHeaders returns {}", static_cast<int>(status));
   } else {
     ENVOY_LOG(trace, "encodeHeaders: Skipped header processing");
@@ -650,6 +627,7 @@ ProcessingRequest Filter::setupBodyChunk(ProcessorState& state, const Buffer::In
                                          bool end_stream) {
   ENVOY_LOG(debug, "Sending a body chunk of {} bytes, end_stream {}", data.length(), end_stream);
   ProcessingRequest req;
+  addAttributes(state, req);
   addDynamicMetadata(state, req);
   auto* body_req = state.mutableBody(req);
   body_req->set_end_of_stream(end_stream);
@@ -667,6 +645,7 @@ void Filter::sendBodyChunk(ProcessorState& state, ProcessorState::CallbackState 
 
 void Filter::sendTrailers(ProcessorState& state, const Http::HeaderMap& trailers) {
   ProcessingRequest req;
+  addAttributes(state, req);
   addDynamicMetadata(state, req);
   auto* trailers_req = state.mutableTrailers(req);
   MutationUtils::headersToProto(trailers, config_->allowedHeaders(), config_->disallowedHeaders(),
@@ -769,6 +748,20 @@ void Filter::addDynamicMetadata(const ProcessorState& state, ProcessingRequest& 
   }
 
   *req.mutable_metadata_context() = forwarding_metadata;
+}
+
+void Filter::addAttributes(const ProcessorState& state, ProcessingRequest& req) {
+  if (!state.sendAttributes(config_->expressionManager())) {
+    return;
+  }
+
+  auto activation_ptr = Filters::Common::Expr::createActivation(
+      &config_->expressionManager().localInfo(), state.callbacks()->streamInfo(),
+      state.requestHeaders(), state.responseHeaders(), state.trailers());
+  attributes = config_->expressionManager().evaluateRequestAttributes(*activation_ptr);
+
+  state.sentAttributes(true);
+  (*req.mutable_attributes())[FilterName] = *attributes;
 }
 
 void Filter::setDynamicMetadata(Http::StreamFilterCallbacks* cb, const ProcessorState& state,

--- a/source/extensions/filters/http/ext_proc/ext_proc.cc
+++ b/source/extensions/filters/http/ext_proc/ext_proc.cc
@@ -312,6 +312,11 @@ FilterHeadersStatus Filter::decodeHeaders(RequestHeaderMap& headers, bool end_st
     decoding_state_.setCompleteBodyAvailable(true);
   }
 
+  // Set the request headers on decoding and encoding state in case they are
+  // needed later.
+  decoding_state_.setRequestHeaders(&headers);
+  encoding_state_.setRequestHeaders(&headers);
+
   FilterHeadersStatus status = FilterHeadersStatus::Continue;
   if (decoding_state_.sendHeaders()) {
     status = onHeaders(decoding_state_, headers, end_stream);
@@ -760,7 +765,7 @@ void Filter::addAttributes(const ProcessorState& state, ProcessingRequest& req) 
       state.requestHeaders(), state.responseHeaders(), state.trailers());
   attributes = config_->expressionManager().evaluateRequestAttributes(*activation_ptr);
 
-  state.sentAttributes(true);
+  state.setSentAttributes(true);
   (*req.mutable_attributes())[FilterName] = *attributes;
 }
 

--- a/source/extensions/filters/http/ext_proc/ext_proc.h
+++ b/source/extensions/filters/http/ext_proc/ext_proc.h
@@ -373,8 +373,7 @@ private:
   void sendImmediateResponse(const envoy::service::ext_proc::v3::ImmediateResponse& response);
 
   Http::FilterHeadersStatus onHeaders(ProcessorState& state,
-                                      Http::RequestOrResponseHeaderMap& headers, bool end_stream,
-                                      ProtobufWkt::Struct* proto);
+                                      Http::RequestOrResponseHeaderMap& headers, bool end_stream);
 
   // Return a pair of whether to terminate returning the current result.
   std::pair<bool, Http::FilterDataStatus> sendStreamChunk(ProcessorState& state);
@@ -386,6 +385,8 @@ private:
   void setDecoderDynamicMetadata(const envoy::service::ext_proc::v3::ProcessingResponse& response);
   void addDynamicMetadata(const ProcessorState& state,
                           envoy::service::ext_proc::v3::ProcessingRequest& req);
+  void addAttributes(const ProcessorState& state,
+                     envoy::service::ext_proc::v3::ProcessingRequest& req);
 
   const FilterConfigSharedPtr config_;
   const ExternalProcessorClientPtr client_;

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -135,9 +135,10 @@ public:
     return body_mode_;
   }
 
+  void setRequestHeaders(Http::RequestOrResponseHeaderMap* headers) { request_headers_ = headers; }
   void setHeaders(Http::RequestOrResponseHeaderMap* headers) { headers_ = headers; }
   void setTrailers(Http::HeaderMap* trailers) { trailers_ = trailers; }
-  virtual const Http::RequestOrResponseHeaderMap* requestHeaders() const PURE;
+  const Http::RequestOrResponseHeaderMap* requestHeaders() const { return request_headers_; };
   virtual const Http::RequestOrResponseHeaderMap* responseHeaders() const PURE;
   const Http::HeaderMap* responseTrailers() const { return trailers_; }
 
@@ -208,7 +209,7 @@ public:
 
   virtual bool sendAttributes(const ExpressionManager& mgr) const PURE;
 
-  void sentAttributes(bool sent) { attributes_sent_ = sent; }
+  void setSentAttributes(bool sent) { attributes_sent_ = sent; }
 
 protected:
   void setBodyMode(
@@ -244,6 +245,10 @@ protected:
   // The specific mode for body handling
   envoy::extensions::filters::http::ext_proc::v3::ProcessingMode_BodySendMode body_mode_;
 
+  // The request_headers_ field is guaranteed to hold the pointer to the request
+  // headers as set in decodeHeaders. This allows both decoding and encoding states
+  // to have access to the request headers map.
+  Http::RequestOrResponseHeaderMap* request_headers_ = nullptr;
   Http::RequestOrResponseHeaderMap* headers_ = nullptr;
   Http::HeaderMap* trailers_ = nullptr;
   Event::TimerPtr message_timer_;
@@ -339,7 +344,6 @@ public:
     return !attributes_sent_ && mgr.hasRequestExpr();
   }
 
-  const Http::RequestOrResponseHeaderMap* requestHeaders() const override { return headers_; };
   const Http::RequestOrResponseHeaderMap* responseHeaders() const override { return nullptr; }
 
 private:
@@ -426,7 +430,6 @@ public:
     return !attributes_sent_ && mgr.hasResponseExpr();
   }
 
-  const Http::RequestOrResponseHeaderMap* requestHeaders() const override { return nullptr; };
   const Http::RequestOrResponseHeaderMap* responseHeaders() const override { return headers_; }
 
 private:

--- a/source/extensions/filters/http/ext_proc/processor_state.h
+++ b/source/extensions/filters/http/ext_proc/processor_state.h
@@ -15,6 +15,7 @@
 #include "source/common/common/logger.h"
 
 #include "absl/status/status.h"
+#include "matching_utils.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -136,6 +137,9 @@ public:
 
   void setHeaders(Http::RequestOrResponseHeaderMap* headers) { headers_ = headers; }
   void setTrailers(Http::HeaderMap* trailers) { trailers_ = trailers; }
+  virtual const Http::RequestOrResponseHeaderMap* requestHeaders() const PURE;
+  virtual const Http::RequestOrResponseHeaderMap* responseHeaders() const PURE;
+  const Http::HeaderMap* responseTrailers() const { return trailers_; }
 
   void onStartProcessorCall(Event::TimerCb cb, std::chrono::milliseconds timeout,
                             CallbackState callback_state);
@@ -202,6 +206,10 @@ public:
 
   virtual Http::StreamFilterCallbacks* callbacks() const PURE;
 
+  virtual bool sendAttributes(const ExpressionManager& mgr) const PURE;
+
+  void sentAttributes(bool sent) { attributes_sent_ = sent; }
+
 protected:
   void setBodyMode(
       envoy::extensions::filters::http::ext_proc::v3::ProcessingMode_BodySendMode body_mode);
@@ -249,6 +257,9 @@ protected:
   const std::vector<std::string>* untyped_forwarding_namespaces_{};
   const std::vector<std::string>* typed_forwarding_namespaces_{};
   const std::vector<std::string>* untyped_receiving_namespaces_{};
+
+  // If true, the attributes for this processing state have already been sent.
+  bool attributes_sent_{};
 
 private:
   virtual void clearRouteCache(const envoy::service::ext_proc::v3::CommonResponse&) {}
@@ -323,6 +334,13 @@ public:
   void clearWatermark() override;
 
   Http::StreamFilterCallbacks* callbacks() const override { return decoder_callbacks_; }
+
+  bool sendAttributes(const ExpressionManager& mgr) const override {
+    return !attributes_sent_ && mgr.hasRequestExpr();
+  }
+
+  const Http::RequestOrResponseHeaderMap* requestHeaders() const override { return headers_; };
+  const Http::RequestOrResponseHeaderMap* responseHeaders() const override { return nullptr; }
 
 private:
   void setProcessingModeInternal(
@@ -403,6 +421,13 @@ public:
   void clearWatermark() override;
 
   Http::StreamFilterCallbacks* callbacks() const override { return encoder_callbacks_; }
+
+  bool sendAttributes(const ExpressionManager& mgr) const override {
+    return !attributes_sent_ && mgr.hasResponseExpr();
+  }
+
+  const Http::RequestOrResponseHeaderMap* requestHeaders() const override { return nullptr; };
+  const Http::RequestOrResponseHeaderMap* responseHeaders() const override { return headers_; }
 
 private:
   void setProcessingModeInternal(

--- a/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
+++ b/test/extensions/filters/http/ext_proc/ext_proc_integration_test.cc
@@ -3429,10 +3429,7 @@ TEST_P(ExtProcIntegrationTest, SendAndReceiveDynamicMetadata) {
 }
 
 #if defined(USE_CEL_PARSER)
-// Test the filter using the default configuration by connecting to
-// an ext_proc server that responds to the request_headers message
-// by requesting to modify the request headers.
-TEST_P(ExtProcIntegrationTest, GetAndSetRequestResponseAttributes) {
+TEST_P(ExtProcIntegrationTest, RequestResponseAttributes) {
   proto_config_.mutable_processing_mode()->set_request_header_mode(ProcessingMode::SEND);
   proto_config_.mutable_processing_mode()->set_response_header_mode(ProcessingMode::SEND);
   proto_config_.mutable_request_attributes()->Add("request.path");


### PR DESCRIPTION

Commit Message: Send attributes with the first message to the server on the request and response paths. Previously the attributes were just sent with headers processing requests
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
Platform Specific Features:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Fixes commit #PR or SHA]
[Optional Deprecated:]
[Optional [API Considerations](https://github.com/envoyproxy/envoy/blob/main/api/review_checklist.md):]
